### PR TITLE
replaced logger.v with logger.t

### DIFF
--- a/lib/src/switcher_api/switcher_api_object.dart
+++ b/lib/src/switcher_api/switcher_api_object.dart
@@ -60,7 +60,7 @@ class SwitcherApiObject {
     if (sDeviceType == SwitcherDevicesTypes.switcherRunner ||
         sDeviceType == SwitcherDevicesTypes.switcherRunnerMini) {
       if (!isSwitcherMessageNew(data, hexSeparatedLetters)) {
-        logger.v('Not new switcher device!');
+        logger.t('Not new switcher device!');
       }
 
       final SwitcherDeviceDirection switcherDeviceDirection =
@@ -79,7 +79,7 @@ class SwitcherApiObject {
     }
 
     if (!isSwitcherMessage(data, hexSeparatedLetters)) {
-      logger.v('Not old switcher device!');
+      logger.t('Not old switcher device!');
     }
 
     final SwitcherDeviceState switcherDeviceState =
@@ -216,7 +216,7 @@ class SwitcherApiObject {
   Future<void> stopBlinds() async {
     if (deviceType != SwitcherDevicesTypes.switcherRunner &&
         deviceType != SwitcherDevicesTypes.switcherRunnerMini) {
-      logger.v('Stop blinds support only for blinds');
+      logger.t('Stop blinds support only for blinds');
       return;
     }
 
@@ -242,7 +242,7 @@ class SwitcherApiObject {
   Future<void> setPosition({int pos = 0}) async {
     if (deviceType != SwitcherDevicesTypes.switcherRunner &&
         deviceType != SwitcherDevicesTypes.switcherRunnerMini) {
-      logger.v('Set position support only blinds');
+      logger.t('Set position support only blinds');
       return;
     }
 


### PR DESCRIPTION
# Description

This pull request addresses a deprecation warning by replacing all instances of `logger.v` with `logger.t`. The change ensures that the logging code complies with the latest recommendations.
